### PR TITLE
accordion pages default to closed

### DIFF
--- a/pages/resources.tsx
+++ b/pages/resources.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const Resources: NextPage<Props> = ({ classes }) => {
-  const [expanded, setExpanded] = useState("panel1");
+  const [expanded, setExpanded] = useState("");
 
   const handleChange = (panel: any) => (event: any, newExpanded: any) => {
     setExpanded(newExpanded ? panel : false);


### PR DESCRIPTION
expanded state default value set to empty string so that no accordion page is defaultly open upon entering resources page