### PR TITLE
Changed the description of the sign up box and moved * requirement to bottom.

### DIFF
--- a/components/VolunteerSignupPopup.tsx
+++ b/components/VolunteerSignupPopup.tsx
@@ -115,9 +115,6 @@ const VolunteerPopup = ({ open, handleClose, email, uid, addVolunteer, onDeleteV
     <Dialog open={open} onClose={handleClose}>
       <DialogTitle className={classes.title}>Volunteer Information</DialogTitle>
       <DialogContent>
-        <Typography style={{ marginRight: '15px', fontStyle: 'italic', fontSize: "0.8rem" }}>
-          (*) Required fields
-        </Typography>
         <TextField
         label="Email"
         value={email}
@@ -189,19 +186,15 @@ const VolunteerPopup = ({ open, handleClose, email, uid, addVolunteer, onDeleteV
           fullWidth
           margin="normal"
         />
-        <FormControlLabel
-          style={{marginTop: "0.75rem", marginBottom: "1.5rem", display: 'flex', alignItems: 'flex-start'}}
-          control={<Checkbox color="primary" checked={certified} onChange={(e) => setCertified(e.target.checked)} style={{transform: 'scale(0.8)', marginTop: "0rem", paddingTop: "0", verticalAlign: "top"}}/>}
-          label={
-            <span style={{ fontSize: 'small', transform: 'scale(0.8)'}}>
-                I certify that I will complete the required <a href="https://canvas.uw.edu/courses/1693188/pages/training-modules?module_item_id=18595279" target='blank'>Training</a> and
-                the review appropriate <a href="https://canvas.uw.edu/courses/1693188/pages/protocols?module_item_id=18595280" target='blank'>Protocols</a> (see project details page for specifics).
-                <span style={{color: "red"}}>*</span>
-            </span>
-          }
-        />
+        <Typography style={{ marginRight: '15px', fontSize: 'small', fontSize: "0.9rem", marginTop: "0.5rem", marginBottom: "0.5rem"}}>
+           Click <a href="https://canvas.uw.edu/courses/1693188/modules" target='blank'>here</a> to learn more
+           about the service learning training and protocols.
+        </Typography>
+        <Typography style={{ marginRight: '15px', fontStyle: 'italic', fontSize: "0.7rem" }}>
+          (*) Required fields
+        </Typography>
         <div className={classes.buttonContainer}>
-            {volunteer ? ( 
+            {volunteer ? (
             <>
               <Button variant="outlined" onClick={() => onDeleteVolunteer(volunteer)} style={{marginRight: "1rem", color: "gray"}}>
                 Withdraw
@@ -214,9 +207,8 @@ const VolunteerPopup = ({ open, handleClose, email, uid, addVolunteer, onDeleteV
               <Button variant="contained" color="primary" onClick={handleSubmit} disabled={isSubmitDisabled}>
                 Signup
               </Button>
-            )} 
+            )}
         </div>
-        
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Task:
![image](https://github.com/slweb-uw/volunteer-site/assets/55634421/e86943e2-2841-4769-999d-2e26ec9e39c1)

- Updated the description of the sign up pop-up to make more sense for the user. 
   - Used to be a checkbox to certify if the user has completed/viewed the training and protocol modules on the service learning page. 
   - Now is a small description with the link to the modules page for the service learning program. 
 - There used to be two different links in the description, where one pointed directly to the training modules and one to the protocol modules. Now, there is one link that takes the user to the overall module page that contains the links to the training and protocol modules and also other useful resources. Here is the new link used: [https://canvas.uw.edu/courses/1693188/modules](url)
 - Moved the * meaning from the top of the page to the bottom as that is more commonly done on other sign up pages (in my opinion! 😄)

New Interface: 
<img width="619" alt="image" src="https://github.com/slweb-uw/volunteer-site/assets/55634421/fde0f237-ee94-48e8-b98a-f6dff3513aa1">

Old Interface: 
![image](https://github.com/slweb-uw/volunteer-site/assets/55634421/d3304038-4166-4463-a41c-5f5dc9984588)