### PR TITLE
Fix: Improve accessibility by adding alt text and correcting list structure

### DIFF
--- a/pages/requiredTraining.tsx
+++ b/pages/requiredTraining.tsx
@@ -29,6 +29,7 @@ const RequiredTraining: NextPage<Props> = ({ classes }) => {
       </Typography>
       <img
         src={"../goldbar.png"}
+        alt=""
         style={{ width: "205px", height: "10px", marginBottom: "30px" }}
       />
       <Grid container spacing={2}>
@@ -47,7 +48,7 @@ const RequiredTraining: NextPage<Props> = ({ classes }) => {
             central to the mission of our program.  Prior to participation in 
             service learning events, please review the materials below.
             </Typography>
-            <div style={{ listStyleType: "none", paddingTop: "20px" }}>
+            <ul style={{ listStyleType: "none", paddingTop: "20px" }}>
               <li>
               <Typography
                   variant="h6"
@@ -107,7 +108,7 @@ const RequiredTraining: NextPage<Props> = ({ classes }) => {
                   </Link>
                 </Typography>
               </li>
-            </div>
+            </ul>
           </div>
         </Grid>
       </Grid>

--- a/pages/standardOfCare.tsx
+++ b/pages/standardOfCare.tsx
@@ -29,6 +29,7 @@ const StandardsOfCarePage: NextPage<Props> = ({ classes }) => {
       </Typography>
       <img
         src={"../goldbar.png"}
+        alt=""
         style={{ width: "355px", height: "10px", marginBottom: "30px" }}
       />
       <Grid container spacing={1}>

--- a/pages/welcome/categoriesOfService.tsx
+++ b/pages/welcome/categoriesOfService.tsx
@@ -31,6 +31,7 @@ const CategoriesOfService: NextPage<Props> = ({ classes }) => {
       </Typography>
       <img
         src={"../goldbar.png"}
+        alt=""
         style={{ width: "380px", height: "10px", marginBottom: "5px" }}
       />
       <Grid container spacing={2}>

--- a/pages/welcome/communitypartners.tsx
+++ b/pages/welcome/communitypartners.tsx
@@ -29,6 +29,7 @@ const Communitypartners = ({ classes }) => {
       </Typography>
       <img
         src={"../goldbar.png"}
+        alt=""
         style={{ width: "550px", height: "10px", marginBottom: "30px" }}
       />
       <Grid container spacing={2}>

--- a/pages/welcome/volunteerProviders.tsx
+++ b/pages/welcome/volunteerProviders.tsx
@@ -31,6 +31,7 @@ const VolunteerProviders: NextPage<Props> = ({ classes }) => {
       </Typography>
       <img
         src={"../goldbar.png"}
+        alt=""
         style={{ width: "550px", height: "10px", marginBottom: "5px" }}
       />
       <div style={{ display: "flex" }}>


### PR DESCRIPTION
This commit addresses several accessibility issues:

- Adds alt="" to decorative gold bar images on multiple pages to hide them from screen readers.
- Corrects the HTML structure in `pages/requiredTraining.tsx` by changing a `div` to a `ul` to properly contain list items.
- Verifies that the location selector dropdown in `pages/opportunities/[location].tsx` has an appropriate accessible label via `aria-labelledby`.