### PR TITLE
Integrating custom claims for roles and authentication

### DIFF
--- a/__tests__/firestore.rules.test.ts
+++ b/__tests__/firestore.rules.test.ts
@@ -1,0 +1,294 @@
+import {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+  RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, deleteDoc, updateDoc } from "firebase/firestore";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: "demo-test",
+    firestore: {
+      rules: readFileSync(resolve(__dirname, "../firestore.rules"), "utf8"),
+      host: "localhost",
+      port: 8080,
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+afterEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+// helpers
+const adminCtx = () =>
+  testEnv.authenticatedContext("admin-uid", { role: "admin" });
+const leadCtx = () =>
+  testEnv.authenticatedContext("lead-uid", { role: "lead" });
+const userCtx = () => testEnv.authenticatedContext("user-uid", { role: null });
+const unauthCtx = () => testEnv.unauthenticatedContext();
+
+// Program collections (Alaska, Idaho, Montana, Seattle, Spokane, Wyoming)
+
+describe("program collections", () => {
+  const collections = [
+    "Alaska",
+    "Idaho",
+    "Montana",
+    "Seattle",
+    "Spokane",
+    "Wyoming",
+  ];
+
+  for (const col of collections) {
+    describe(col, () => {
+      it("allows anyone to read", async () => {
+        await assertSucceeds(
+          getDoc(doc(unauthCtx().firestore(), `${col}/doc1`)),
+        );
+      });
+
+      it("allows admin to write", async () => {
+        await assertSucceeds(
+          setDoc(doc(adminCtx().firestore(), `${col}/doc1`), { name: "test" }),
+        );
+      });
+
+      it("denies lead from writing", async () => {
+        await assertFails(
+          setDoc(doc(leadCtx().firestore(), `${col}/doc1`), { name: "test" }),
+        );
+      });
+
+      it("denies signed-in non-admin from writing", async () => {
+        await assertFails(
+          setDoc(doc(userCtx().firestore(), `${col}/doc1`), { name: "test" }),
+        );
+      });
+
+      it("denies unauthenticated from writing", async () => {
+        await assertFails(
+          setDoc(doc(unauthCtx().firestore(), `${col}/doc1`), { name: "test" }),
+        );
+      });
+    });
+  }
+});
+
+// Events
+
+describe("events", () => {
+  it("allows anyone to read", async () => {
+    await assertSucceeds(getDoc(doc(unauthCtx().firestore(), "events/evt1")));
+  });
+
+  it("allows admin to create", async () => {
+    await assertSucceeds(
+      setDoc(doc(adminCtx().firestore(), "events/evt1"), { openings: 5 }),
+    );
+  });
+
+  it("allows lead to create", async () => {
+    await assertSucceeds(
+      setDoc(doc(leadCtx().firestore(), "events/evt1"), { openings: 5 }),
+    );
+  });
+
+  it("denies signed-in user from creating", async () => {
+    await assertFails(
+      setDoc(doc(userCtx().firestore(), "events/evt1"), { openings: 5 }),
+    );
+  });
+
+  it("allows admin to delete", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertSucceeds(deleteDoc(doc(adminCtx().firestore(), "events/evt1")));
+  });
+
+  it("allows lead to delete", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertSucceeds(deleteDoc(doc(leadCtx().firestore(), "events/evt1")));
+  });
+
+  it("denies user from deleting", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertFails(deleteDoc(doc(userCtx().firestore(), "events/evt1")));
+  });
+
+  it("denies unauthenticated from deleting", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertFails(deleteDoc(doc(unauthCtx().firestore(), "events/evt1")));
+  });
+
+  it("allows signed-in user to decrement openings only", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertSucceeds(
+      updateDoc(doc(userCtx().firestore(), "events/evt1"), { openings: 4 }),
+    );
+  });
+
+  it("denies signed-in user from setting openings below 0", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 0 });
+    });
+    await assertFails(
+      updateDoc(doc(userCtx().firestore(), "events/evt1"), { openings: -1 }),
+    );
+  });
+
+  it("denies signed-in user from updating fields other than openings", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), {
+        openings: 5,
+        title: "old",
+      });
+    });
+    await assertFails(
+      updateDoc(doc(userCtx().firestore(), "events/evt1"), { title: "hacked" }),
+    );
+  });
+
+  it("allows lead to update any field", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5, title: "old" });
+    });
+    await assertSucceeds(
+      updateDoc(doc(leadCtx().firestore(), "events/evt1"), { title: "updated" }),
+    );
+  });
+
+  it("denies unauthenticated from updating", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "events/evt1"), { openings: 5 });
+    });
+    await assertFails(
+      updateDoc(doc(unauthCtx().firestore(), "events/evt1"), { openings: 4 }),
+    );
+  });
+});
+
+// Events / volunteers subcollection
+
+describe("events/volunteers subcollection", () => {
+  it("denies unauthenticated read", async () => {
+    await assertFails(
+      getDoc(doc(unauthCtx().firestore(), "events/evt1/volunteers/vol1")),
+    );
+  });
+
+  it("allows signed-in user to read", async () => {
+    await assertSucceeds(
+      getDoc(doc(userCtx().firestore(), "events/evt1/volunteers/vol1")),
+    );
+  });
+
+  it("allows user to write their own volunteer doc (uid_suffix format)", async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(userCtx().firestore(), "events/evt1/volunteers/user-uid_slot1"),
+        { name: "me" },
+      ),
+    );
+  });
+
+  it("denies user from writing another user's volunteer doc", async () => {
+    await assertFails(
+      setDoc(
+        doc(userCtx().firestore(), "events/evt1/volunteers/other-uid_slot1"),
+        { name: "not me" },
+      ),
+    );
+  });
+
+  it("allows admin to write any volunteer doc", async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(adminCtx().firestore(), "events/evt1/volunteers/anyone_slot1"),
+        { name: "anyone" },
+      ),
+    );
+  });
+
+  it("allows lead to write any volunteer doc", async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(leadCtx().firestore(), "events/evt1/volunteers/anyone_slot1"),
+        { name: "anyone" },
+      ),
+    );
+  });
+});
+
+// role collections (Admin, Leads, Volunteers)
+
+describe("role collections", () => {
+  const roleCols = ["Admins", "Leads", "Volunteers"];
+
+  for (const col of roleCols) {
+    describe(col, () => {
+      it("allows admin to read", async () => {
+        await assertSucceeds(
+          getDoc(doc(adminCtx().firestore(), `${col}/doc1`)),
+        );
+      });
+
+      it("allows admin to write", async () => {
+        await assertSucceeds(
+          setDoc(doc(adminCtx().firestore(), `${col}/doc1`), {
+            email: "a@b.com",
+          }),
+        );
+      });
+
+      it("denies lead from reading", async () => {
+        await assertFails(getDoc(doc(leadCtx().firestore(), `${col}/doc1`)));
+      });
+
+      it("denies lead from writing", async () => {
+        await assertFails(
+          setDoc(doc(leadCtx().firestore(), `${col}/doc1`), { email: "a@b.com" }),
+        );
+      });
+
+      it("denies signed-in user from reading", async () => {
+        await assertFails(getDoc(doc(userCtx().firestore(), `${col}/doc1`)));
+      });
+
+      it("denies unauthenticated from reading", async () => {
+        await assertFails(getDoc(doc(unauthCtx().firestore(), `${col}/doc1`)));
+      });
+    });
+  }
+});
+
+// cache
+describe("cache", () => {
+  it("allows anyone to read", async () => {
+    await assertSucceeds(getDoc(doc(unauthCtx().firestore(), "cache/doc1")));
+  });
+
+  it("denies anyone from writing", async () => {
+    await assertFails(
+      setDoc(doc(adminCtx().firestore(), "cache/doc1"), { data: "x" }),
+    );
+  });
+});

--- a/auth.tsx
+++ b/auth.tsx
@@ -51,7 +51,6 @@ export function AuthProvider({ children }: any) {
         // fetch user custom claim integrated within JWT token
         const authToken = await user.getIdTokenResult();
         const role = authToken.claims.role; // 'admin' || 'lead' || 'volunteer' || undefined (aka student)
-
         if (role === "admin") {
           setIsAdmin(true);
           setIsAuthorized(true);
@@ -60,9 +59,11 @@ export function AuthProvider({ children }: any) {
           setIsAuthorized(true);
         } else if (role === "volunteer") {
           setIsAuthorized(true);
-        } else {
-          // regular student
+        } else if (user.email?.endsWith("@uw.edu")) {
           setIsAuthorized(true);
+        } else {
+          // non-uw account that isn't authorized
+          setIsAuthorized(false);
         }
 
         const token = await user.getIdToken();

--- a/auth.tsx
+++ b/auth.tsx
@@ -60,7 +60,11 @@ export function AuthProvider({ children }: any) {
           setIsAuthorized(true);
         } else if (role === "volunteer") {
           setIsAuthorized(true);
+        } else {
+          // regular student
+          setIsAuthorized(true);
         }
+
         const token = await user.getIdToken();
         setUser(user);
         nookies.set(undefined, "token", token, {});

--- a/auth.tsx
+++ b/auth.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useContext, createContext } from "react";
 import nookies from "nookies";
-import { db } from "firebaseClient";
-import { getDocs, collection, query, where, limit } from "firebase/firestore";
 import { getAuth, onIdTokenChanged, User } from "firebase/auth";
 import { auth } from "firebaseClient";
 
@@ -37,53 +35,32 @@ export function AuthProvider({ children }: any) {
     const fetchData = async () => {
       const user = getAuth().currentUser;
 
+      // on sign-out, store values back to false
+      setUser(null);
+      setIsAdmin(false);
+      setIsLead(false);
+      setIsAuthorized(false);
+
       if (!user) {
-        setUser(null);
-        setIsAdmin(false);
-        setIsLead(false);
-        setIsAuthorized(false);
         nookies.set(undefined, "token", "", {});
         setIsLoading(false);
         return;
       }
 
       try {
-        // Check if Admin
-        const adminQuery = query(
-          collection(db, "Admins"),
-          where("email", "==", user.email),
-          limit(1),
-        );
-        const adminSnapshot = await getDocs(adminQuery);
-        const userIsAdmin = !adminSnapshot.empty;
-        setIsAdmin(userIsAdmin);
+        // fetch user custom claim integrated within JWT token
+        const authToken = await user.getIdTokenResult();
+        const role = authToken.claims.role; // 'admin' || 'lead' || 'volunteer' || undefined (aka student)
 
-        // Check if Lead
-        const leadQuery = query(
-          collection(db, "Leads"),
-          where("email", "==", user.email),
-          limit(1),
-        );
-        const leadSnapshot = await getDocs(leadQuery);
-        const userIsLead = !leadSnapshot.empty;
-        setIsLead(userIsLead);
-
-        // Check if Authorized
-        let userIsAuthorized =
-          userIsAdmin || (user.email && user.email.endsWith("@uw.edu"));
-
-        // Only query the Volunteers collection if they aren't already authorized
-        if (!userIsAuthorized) {
-          const volunteerQuery = query(
-            collection(db, "Volunteers"),
-            where("email", "==", user.email),
-            limit(1),
-          );
-          const volunteerSnapshot = await getDocs(volunteerQuery);
-          userIsAuthorized = !volunteerSnapshot.empty;
+        if (role === "admin") {
+          setIsAdmin(true);
+          setIsAuthorized(true);
+        } else if (role === "lead") {
+          setIsLead(true);
+          setIsAuthorized(true);
+        } else if (role === "volunteer") {
+          setIsAuthorized(true);
         }
-        setIsAuthorized(userIsAuthorized);
-
         const token = await user.getIdToken();
         setUser(user);
         nookies.set(undefined, "token", token, {});

--- a/components/projectsList.tsx
+++ b/components/projectsList.tsx
@@ -85,9 +85,12 @@ const Events: React.FC<EventsProps> = ({ location, classes }) => {
     // Load events
     loadEvents();
     const cacheRef = doc(db, "cache", location.toString());
-    getDoc(cacheRef).then((doc) =>
-      setOrganizations(Object.keys(doc.data() as string[]).sort()),
-    );
+    getDoc(cacheRef).then((doc) => {
+      if (doc.exists()) {
+        setOrganizations(Object.keys(doc.data()).sort());
+      }
+    });
+
     // pull organizations for this location from the metadata cache
   }, [location]);
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "codegen:prod": "ts-node --project tsconfig.node.json ./scripts/codegen_prod.ts",
     "migrate:dev": "nodemon -e ts --ignore generated -x ts-node --project tsconfig.node.json ./scripts/migrate_dev.ts",
     "migrate:staging": "ts-node --project tsconfig.node.json ./scripts/migrate_staging.ts",
-    "migrate:prod": "ts-node --project tsconfig.node.json ./scripts/migrate_prod.ts"
+    "migrate:prod": "ts-node --project tsconfig.node.json ./scripts/migrate_prod.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.7.1",
@@ -74,14 +75,18 @@
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "4.0.0",
     "@types/deep-equal": "^1.0.1",
+    "@types/jest": "^29.5.14",
     "@types/memory-cache": "^0.2.1",
     "@types/react": "^18.2.73",
     "@types/sanitize-html": "^2.6.2",
     "@types/styled-components": "^5.1.3",
     "babel-plugin-superjson-next": "^0.4.5",
     "eslint": "8",
-    "eslint-config-next": "14.2.3"
+    "eslint-config-next": "14.2.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.11"
   },
   "browser": {
     "child_process": false

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -8,7 +8,7 @@ export default async function handler(
   if (req.method != "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
-  // only admins allowed to set roles (TODO: make a script to set custom claims for pre-existing users)
+  // only admins allowed to set roles
   const token = req.headers.authorization?.split("Bearer ")[1];
   // no token = not authenticated
   if (!token) {
@@ -28,7 +28,7 @@ export default async function handler(
   if (!email || typeof email != "string") {
     return res.status(400).json({ error: "Invalid email" });
   }
-  if (!["admin", "lead", "volunteer"].includes(role)) {
+  if (role != null && !["admin", "lead", "volunteer"].includes(role)) {
     return res.status(400).json({ error: "Invalid role" });
   }
   // validate email actually exists in Firebase

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -23,16 +23,21 @@ export default async function handler(
   } catch (error) {
     return res.status(401).json({ error: "Invalid token" });
   }
-  const { uid, role } = req.body;
-  // check if uid is non-null and role is valid value
-  if (!uid || typeof uid != "string") {
-    return res.status(400).json({ error: "Invalid uid" });
+  const { email, role } = req.body;
+  // check if email is non-null and role is valid value
+  if (!email || typeof email != "string") {
+    return res.status(400).json({ error: "Invalid email" });
   }
   if (!["admin", "lead", "volunteer"].includes(role)) {
     return res.status(400).json({ error: "Invalid role" });
   }
-
-  await firebaseAdmin.auth().setCustomUserClaims(uid, { role });
+  // validate email actually exists in Firebase
+  try {
+    const userRecord = await firebaseAdmin.auth().getUserByEmail(email);
+    await firebaseAdmin.auth().setCustomUserClaims(userRecord.uid, { role });
+  } catch (error) {
+    return res.status(404).json({ error: "No account found for this email" });
+  }
 
   return res.status(200).json({ success: true });
 }

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { firebaseAdmin } from "../../firebaseAdmin";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method != "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  // only admins allowed to set roles (TODO: make a script to set custom claims for pre-existing users)
+  const token = req.headers.authorization?.split("Bearer ")[1];
+  // no token = not authenticated
+  if (!token) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  try {
+    const decoded = await firebaseAdmin.auth().verifyIdToken(token);
+    // authenticated but not authorized
+    if (decoded.role != "admin") {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+  } catch (error) {
+    return res.status(401).json({ error: "Invalid token" });
+  }
+  const { uid, role } = req.body;
+  // check if uid is non-null and role is valid value
+  if (!uid || typeof uid != "string") {
+    return res.status(400).json({ error: "Invalid uid" });
+  }
+  if (!["admin", "lead", "volunteer"].includes(role)) {
+    return res.status(400).json({ error: "Invalid role" });
+  }
+
+  await firebaseAdmin.auth().setCustomUserClaims(uid, { role });
+
+  return res.status(200).json({ success: true });
+}

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -33,7 +33,9 @@ export default async function handler(
   }
   // validate email actually exists in Firebase
   try {
+    // throws an error if user not found by email
     const userRecord = await firebaseAdmin.auth().getUserByEmail(email);
+
     await firebaseAdmin.auth().setCustomUserClaims(userRecord.uid, { role });
   } catch (error) {
     return res.status(404).json({ error: "No account found for this email" });

--- a/pages/userManager.tsx
+++ b/pages/userManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { db } from "firebaseClient";
+import { db, auth } from "firebaseClient";
 import {
   addDoc,
   collection,
@@ -192,7 +192,7 @@ const AdminPage = () => {
     };
   }, []);
 
-  const addUser = (e) => {
+  const addUser = async (e) => {
     e.preventDefault();
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     setExistentEmail(false);
@@ -203,9 +203,11 @@ const AdminPage = () => {
       return;
     }
 
-    var existentEmail;
+    let existentEmail;
     if (activeSection === "Admins") {
       existentEmail = admins.find((admin) => admin.email === newUserEmail);
+    } else if (activeSection == "Leads") {
+      existentEmail = leads.find((lead) => lead.email === newUserEmail);
     } else {
       existentEmail = volunteers.find(
         (volunteer) => volunteer.email === newUserEmail,
@@ -216,7 +218,27 @@ const AdminPage = () => {
       setNewUserEmail("");
       return;
     }
+    const roleMap = { Admins: "admin", Leads: "lead", Volunteers: "volunteer" };
+    const token = await auth.currentUser?.getIdToken();
+    // query endpoint to check if email that we are changing role of exists + set custom claims if it does
+    const res = await fetch("/api/set-roles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        email: newUserEmail,
+        role: roleMap[activeSection],
+      }),
+    });
 
+    if (!res.ok) {
+      const { error } = await res.json();
+      console.error(error);
+      return;
+    }
+    // add to collection to display who has which role
     addDoc(collection(db, activeSection), {
       email: newUserEmail,
       timestamp: serverTimestamp(),

--- a/pages/userManager.tsx
+++ b/pages/userManager.tsx
@@ -252,7 +252,21 @@ const AdminPage = () => {
       });
   };
 
-  const removeUser = (userEmail) => {
+  const removeUser = async (userEmail) => {
+    const token = await auth.currentUser?.getIdToken();
+    const res = await fetch("/api/set-roles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ email: userEmail, role: null }),
+    });
+
+    if (!res.ok) {
+      console.error("Failed to remove claim");
+      return;
+    }
     const usersRef = collection(db, activeSection);
     getDocs(query(usersRef, where("email", "==", userEmail)))
       .then((querySnapshot) => {

--- a/scripts/setExistingUserClaims.ts
+++ b/scripts/setExistingUserClaims.ts
@@ -1,0 +1,27 @@
+import { firebaseAdmin } from "../firebaseAdmin";
+
+const db = firebaseAdmin.firestore();
+const adminAuth = firebaseAdmin.auth();
+const roleMap: Record<string, string> = {
+  Admins: "admin",
+  Leads: "lead",
+  Volunteers: "volunteer",
+};
+
+async function main() {
+  for (const [col, role] of Object.entries(roleMap)) {
+    const snapshot = await db.collection(col).get();
+    for (const doc of snapshot.docs) {
+      const { email } = doc.data();
+      try {
+        const user = await adminAuth.getUserByEmail(email);
+        await adminAuth.setCustomUserClaims(user.uid, { role });
+        console.log(`Set ${role} claim for ${email}`);
+      } catch {
+        console.warn(`No auth account for ${email}, skipping`);
+      }
+    }
+  }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "skipLibCheck": true,
+    "types": ["jest"],
     "baseUrl": ".",
     "incremental": true
   },


### PR DESCRIPTION
Refactored auth.tsx to check custom claims for roles instead of querying multiple collections. Created a new backend endpoint for setting role for a given user which is queried by userManager route. 