### PR TITLE
Fix with withdrawal for events (Unable to withdrawal if slots were full)

### DIFF
--- a/components/VolunteerSignupGrid.tsx
+++ b/components/VolunteerSignupGrid.tsx
@@ -8,6 +8,7 @@ interface VolunteerSignupGridProps {
   eventData: EventData;
   volunteers: VolunteerData[];
   onSignUp: (role: string, date: string) => void;
+  currentUserId?: string;
   relevantDates: string[];
   targetDay: number | string | string[];
 };
@@ -44,6 +45,7 @@ const VolunteerSignupGrid: React.FC<VolunteerSignupGridProps> = ({
   eventData,
   volunteers,
   onSignUp,
+  currentUserId,
   relevantDates,
   targetDay
 }) => {
@@ -177,9 +179,12 @@ const VolunteerSignupGrid: React.FC<VolunteerSignupGridProps> = ({
               const spotsOpen = eventData.openings?.[dateKey]?.[role] ?? 0;
               const isFull = spotsOpen <= 0;
               const pastEvent = isPastDate(dateStr);
+              const isCurrentUserSignedUp = cellVolunteers.some((v) => v.uid === currentUserId);
+              const isDisabled = pastEvent || (isFull && !isCurrentUserSignedUp);
 
               let buttonText = 'BE THE FIRST!';
               if (pastEvent) buttonText = 'PAST EVENT';
+              else if (isCurrentUserSignedUp) buttonText = 'EDIT MY SIGNUP';
               else if (isFull) buttonText = 'FULL';
               else if (cellVolunteers.length > 0) buttonText = `JOIN : ${spotsOpen} spot(s) left`;
 
@@ -223,21 +228,21 @@ const VolunteerSignupGrid: React.FC<VolunteerSignupGridProps> = ({
                   {/* Action Button Area */}
                   <Button
                     fullWidth
-                    disabled={isFull || pastEvent}
+                    disabled={isDisabled}
                     onClick={() => onSignUp(role, dateStr)}
-                    endIcon={!isFull && !pastEvent && <ArrowForwardIcon fontSize="small" />}
+                    endIcon={!isDisabled && <ArrowForwardIcon fontSize="small" />}
                     sx={{
                       borderRadius: '20px',
                       py: 0.5,
-                      bgcolor: (isFull || pastEvent) ? '#f5f5f5' : COLORS.btnBg,
-                      color: (isFull || pastEvent) ? '#aaa' : COLORS.btnText,
+                      bgcolor: isDisabled ? '#f5f5f5' : COLORS.btnBg,
+                      color: isDisabled ? '#aaa' : COLORS.btnText,
                       fontWeight: 700,
                       fontSize: '0.75rem',
                       letterSpacing: '1px',
-                      border: `1px solid ${(isFull || pastEvent) ? '#eee' : COLORS.btnBorder}`,
+                      border: `1px solid ${isDisabled ? '#eee' : COLORS.btnBorder}`,
                       boxShadow: 'none',
                      '&:hover': {
-                        bgcolor: (isFull || pastEvent) ? '#f5f5f5' : '#e0d4c0',
+                        bgcolor: isDisabled ? '#f5f5f5' : '#e0d4c0',
                         boxShadow: 'none',
                       },
                     }}

--- a/components/VolunteerSignupPopup.tsx
+++ b/components/VolunteerSignupPopup.tsx
@@ -190,7 +190,7 @@ const VolunteerPopup = ({ open, handleClose, email, name, uid, phone, position, 
               <Button variant="contained" color="secondary" onClick={handleClose}>
                 Cancel
               </Button>
-              <Button variant="outlined" onClick={() => onDeleteVolunteer(volunteer)} style={{color: "gray"}}>
+              <Button variant="outlined" onClick={() => onDeleteVolunteer(volunteer)} style={{color: "#c62828", borderColor: "#c62828"}}>
                 Withdraw
               </Button>
               <Button variant="contained" color="primary" onClick={handleSubmit} disabled={isSubmitDisabled}>

--- a/pages/calendar/[event]/signup.tsx
+++ b/pages/calendar/[event]/signup.tsx
@@ -384,6 +384,7 @@ const Event = ({
             eventData={eventData}
             volunteers={volunteer}
             onSignUp={handleOpenVolunteerPopup}
+            currentUserId={user?.uid}
             relevantDates={datesInfo[0] as string[]}
             targetDay={datesInfo.length > 1 ? datesInfo[1] : datesInfo[0]}
           />


### PR DESCRIPTION
If a role was filled for someone who was signed up, they wouldn't be able to withdraw since the button is conditionally disabled if the event has reached capacity or if it is a past event