### PR TITLE
Fix custom claim authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 #firebase info
 sign-up-9453b-firebase-adminsdk-ahys9-1b56bc2534.json
+
+# TypeScript
+tsconfig.tsbuildinfo

--- a/auth.tsx
+++ b/auth.tsx
@@ -54,7 +54,7 @@ export function AuthProvider({ children }: any) {
 
         // no role on the token yet — check if one was pre-assigned by email
         // before this account existed, and apply it if so
-        if (!role) {
+        if (authToken.claims.authorized === undefined) {
           try {
             const idToken = await user.getIdToken();
             const res = await fetch("/api/reconcile-role", {
@@ -65,12 +65,8 @@ export function AuthProvider({ children }: any) {
               },
             });
             if (res.ok) {
-              const { role: reconciledRole, authorized: isAuthorized } = await res.json();
-              if (reconciledRole || isAuthorized) {
-                // claim was just set server-side — force a fresh token to see it
-                const freshToken = await user.getIdTokenResult(true);
-                role = freshToken.claims.role;
-              }
+              const freshToken = await user.getIdTokenResult(true);
+              role = freshToken.claims.role;
             }
           } catch (error) {
             console.error("Error reconciling role:", error);

--- a/auth.tsx
+++ b/auth.tsx
@@ -65,8 +65,8 @@ export function AuthProvider({ children }: any) {
               },
             });
             if (res.ok) {
-              const { role: reconciledRole } = await res.json();
-              if (reconciledRole) {
+              const { role: reconciledRole, authorized: isAuthorized } = await res.json();
+              if (reconciledRole || isAuthorized) {
                 // claim was just set server-side — force a fresh token to see it
                 const freshToken = await user.getIdTokenResult(true);
                 role = freshToken.claims.role;
@@ -76,7 +76,7 @@ export function AuthProvider({ children }: any) {
             console.error("Error reconciling role:", error);
           }
         }
-        console.log(role);
+
         if (role === "admin") {
           setIsAdmin(true);
           setIsAuthorized(true);
@@ -85,7 +85,7 @@ export function AuthProvider({ children }: any) {
           setIsAuthorized(true);
         } else if (role === "volunteer") {
           setIsAuthorized(true);
-        } else if (user.email?.endsWith("@uw.edu")) {
+        } else if (user.email?.toLowerCase().endsWith("@uw.edu")) {
           setIsAuthorized(true);
         } else {
           // non-uw account that isn't authorized

--- a/pages/api/reconcile-role.ts
+++ b/pages/api/reconcile-role.ts
@@ -56,5 +56,5 @@ export default async function handler(
     await firebaseAdmin.auth().setCustomUserClaims(decoded.uid, {role: null, authorized})
   }
 
-  return res.status(200).json({ role: null });
+  return res.status(200).json({ role: null, authorized });
 }

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -23,7 +23,7 @@ export default async function handler(
   } catch (error) {
     return res.status(401).json({ error: "Invalid token" });
   }
-  const { email, role } = req.body;
+  const { email, role, authorized } = req.body;
   // check if email is non-null and role is valid value
   if (!email || typeof email != "string") {
     return res.status(400).json({ error: "Invalid email" });
@@ -36,7 +36,7 @@ export default async function handler(
     // throws an error if user not found by email
     const userRecord = await firebaseAdmin.auth().getUserByEmail(email);
 
-    await firebaseAdmin.auth().setCustomUserClaims(userRecord.uid, { role });
+    await firebaseAdmin.auth().setCustomUserClaims(userRecord.uid, { role, authorized });
   } catch (error) {
     return res.status(404).json({ error: "No account found for this email" });
   }

--- a/pages/api/set-roles.ts
+++ b/pages/api/set-roles.ts
@@ -24,6 +24,9 @@ export default async function handler(
     return res.status(401).json({ error: "Invalid token" });
   }
   const { email, role, authorized } = req.body;
+  if (typeof authorized != "boolean") {
+    return res.status(400).json({error: "Invalid authorized flag"})
+  }
   // check if email is non-null and role is valid value
   if (!email || typeof email != "string") {
     return res.status(400).json({ error: "Invalid email" });

--- a/pages/userManager.tsx
+++ b/pages/userManager.tsx
@@ -233,7 +233,7 @@ const AdminPage = () => {
       body: JSON.stringify({
         email: newUserEmail,
         role: roleMap[activeSection],
-        authorizd: true
+        authorized: true
       }),
     });
 
@@ -294,7 +294,7 @@ const AdminPage = () => {
       body: JSON.stringify({ email: userEmail, role: null, authorized: false }),
     });
 
-    if (!res.ok) {
+    if (!res.ok && res.status !== 404) {
       const { error } = await res.json();
       enqueueSnackbar(`Error Removing User: ${error}`, {
         variant: "error",
@@ -308,10 +308,17 @@ const AdminPage = () => {
         query(usersRef, where("email", "==", userEmail)),
       );
       await Promise.all(querySnapshot.docs.map((doc) => deleteDoc(doc.ref)));
-      enqueueSnackbar("User removed successfully", {
-        variant: "success",
-        autoHideDuration: 3000,
-      });
+      if (res.status === 404) {
+        enqueueSnackbar("User role removed successfully (Note: an account hasn't been created with this email)", {
+          variant: "success",
+          autoHideDuration: 3000,
+        });
+      }else {
+        enqueueSnackbar("User removed successfully", {
+          variant: "success",
+          autoHideDuration: 3000,
+        });
+      }
     } catch (error) {
       console.error("Error removing user: ", error);
       enqueueSnackbar("Error removing user from directory", {

--- a/pages/userManager.tsx
+++ b/pages/userManager.tsx
@@ -233,6 +233,7 @@ const AdminPage = () => {
       body: JSON.stringify({
         email: newUserEmail,
         role: roleMap[activeSection],
+        authorizd: true
       }),
     });
 
@@ -290,7 +291,7 @@ const AdminPage = () => {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ email: userEmail, role: null }),
+      body: JSON.stringify({ email: userEmail, role: null, authorized: false }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
We need to introduce another custom claim since if a user doesn't have a role, we need to distinguish them from a random person vs. a @uw.edu student. Right now, are security rules don't have anyway of distinguishing this so this implements the logic for verifying a user that doesn't have a role is a @uw.edu student (authorized automatically).