### PR TITLE
Notify admins on unauthorized signup + invite links for preceptors (#207)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ NEXT_PUBLIC_MEASUREMENT_ID=<your_key_here>
 FB_PRIVATE_KEY=<your_key_here>
 FB_CLIENT_EMAIL=<your_key_here>
 FB_PROJECT_ID=<your_key_here>
+
+// used to build links inside notification emails (e.g. https://somserve.org)
+NEXT_PUBLIC_SITE_URL=<your_site_url_here>
+
+// comma-separated list of emails notified when a non-UW user signs up
+// unauthorized. Requires the Firebase "Trigger Email" extension to be
+// enabled and configured with SMTP credentials in the Firebase console.
+ADMIN_NOTIFICATION_EMAILS=<comma_separated_emails_here>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Footer: React.FC<{}> = () => {
-  const { isAdmin } = useAuth();
+  const { isAdmin, isLead } = useAuth();
 
   return (
     <footer className={useStyles().footer}>
@@ -58,10 +58,18 @@ const Footer: React.FC<{}> = () => {
           experience on this website.
         </i>
       </Typography>
+      {(isAdmin || isLead) && (
+        <Link
+          href="/invitePreceptor"
+          style={{ color: "white", paddingTop: "100px", fontWeight: 600 }}
+        >
+          Invite a Preceptor
+        </Link>
+      )}
       {isAdmin && (
         <Link
           href="/userManager"
-          style={{ color: "white", paddingTop: "100px", fontWeight: 600 }}
+          style={{ color: "white", paddingTop: isLead ? "0" : "100px", fontWeight: 600 }}
         >
           User Manager
         </Link>

--- a/helpers/invites.ts
+++ b/helpers/invites.ts
@@ -1,0 +1,16 @@
+import crypto from "crypto";
+
+export const INVITE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+export function generateInviteToken(): string {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+// Which roles a given caller is allowed to hand out via an invite link.
+// Admin-level access is deliberately never invitable this way — that stays
+// a manual User Manager action.
+export function rolesInvitableBy(callerRole: string | undefined): string[] {
+  if (callerRole === "admin") return ["lead", "volunteer"];
+  if (callerRole === "lead") return ["volunteer"];
+  return [];
+}

--- a/helpers/notifyAdmins.ts
+++ b/helpers/notifyAdmins.ts
@@ -1,0 +1,34 @@
+import { firebaseAdmin } from "../firebaseAdmin";
+
+// Firebase's "Trigger Email" extension watches this collection and sends
+// whatever gets added to it. Must be enabled + configured with SMTP
+// credentials in the Firebase console for this to actually deliver mail.
+const MAIL_COLLECTION = "mail";
+
+export async function notifyAdminsOfPendingAuthorization(applicantEmail: string) {
+  const recipients = (process.env.ADMIN_NOTIFICATION_EMAILS || "")
+    .split(",")
+    .map((email) => email.trim())
+    .filter(Boolean);
+
+  if (recipients.length === 0) {
+    console.warn(
+      "ADMIN_NOTIFICATION_EMAILS is not set — skipping pending authorization notification for",
+      applicantEmail,
+    );
+    return;
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+
+  await firebaseAdmin.firestore().collection(MAIL_COLLECTION).add({
+    to: recipients,
+    message: {
+      subject: `New preceptor awaiting authorization: ${applicantEmail}`,
+      html: `
+        <p><strong>${applicantEmail}</strong> just signed up with a non-UW email and has no matching role yet.</p>
+        <p>Grant them access in <a href="${siteUrl}/userManager">User Manager</a>.</p>
+      `,
+    },
+  });
+}

--- a/pages/api/create-invite.ts
+++ b/pages/api/create-invite.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { firebaseAdmin } from "../../firebaseAdmin";
+import { generateInviteToken, rolesInvitableBy, INVITE_TTL_MS } from "../../helpers/invites";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method != "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const token = req.headers.authorization?.split("Bearer ")[1];
+  if (!token) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  let decoded;
+  try {
+    decoded = await firebaseAdmin.auth().verifyIdToken(token);
+  } catch (error) {
+    return res.status(401).json({ error: "Invalid token" });
+  }
+
+  const allowedRoles = rolesInvitableBy(decoded.role as string | undefined);
+  if (allowedRoles.length === 0) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
+  const { email, role } = req.body;
+  if (!email || typeof email != "string") {
+    return res.status(400).json({ error: "Invalid email" });
+  }
+  if (!allowedRoles.includes(role)) {
+    return res.status(400).json({ error: "Invalid role" });
+  }
+
+  const normalizedEmail = email.toLowerCase().trim();
+  const inviteToken = generateInviteToken();
+  const now = Date.now();
+
+  await firebaseAdmin
+    .firestore()
+    .collection("Invites")
+    .doc(inviteToken)
+    .set({
+      email: normalizedEmail,
+      role,
+      createdByUid: decoded.uid,
+      createdByEmail: decoded.email ?? null,
+      createdAt: firebaseAdmin.firestore.Timestamp.fromMillis(now),
+      expiresAt: firebaseAdmin.firestore.Timestamp.fromMillis(now + INVITE_TTL_MS),
+      usedAt: null,
+    });
+
+  return res.status(200).json({ token: inviteToken });
+}

--- a/pages/api/reconcile-role.ts
+++ b/pages/api/reconcile-role.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { firebaseAdmin } from "../../firebaseAdmin";
+import { notifyAdminsOfPendingAuthorization } from "../../helpers/notifyAdmins";
 
 // Collections an admin can pre-assign a role to by email, before that
 // person has an account. Checked in priority order.
@@ -49,12 +50,16 @@ export default async function handler(
       return res.status(200).json({ role });
     }
   }
-  if (decoded.email && decoded.email.toLowerCase().endsWith("@uw.edu")) {
+  if (decoded.email.toLowerCase().endsWith("@uw.edu")) {
     authorized = true;
-    await firebaseAdmin.auth().setCustomUserClaims(decoded.uid, {role: null, authorized})
   } else {
-    await firebaseAdmin.auth().setCustomUserClaims(decoded.uid, {role: null, authorized})
+    try {
+      await notifyAdminsOfPendingAuthorization(decoded.email);
+    } catch (error) {
+      console.error("Error notifying admins of pending authorization:", error);
+    }
   }
+  await firebaseAdmin.auth().setCustomUserClaims(decoded.uid, { role: null, authorized });
 
   return res.status(200).json({ role: null, authorized });
 }

--- a/pages/api/redeem-invite.ts
+++ b/pages/api/redeem-invite.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { firebaseAdmin } from "../../firebaseAdmin";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method != "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const authToken = req.headers.authorization?.split("Bearer ")[1];
+  if (!authToken) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  let decoded;
+  try {
+    decoded = await firebaseAdmin.auth().verifyIdToken(authToken);
+  } catch (error) {
+    return res.status(401).json({ error: "Invalid token" });
+  }
+
+  const { token } = req.body;
+  if (!token || typeof token != "string") {
+    return res.status(400).json({ error: "Invalid invite token" });
+  }
+
+  const db = firebaseAdmin.firestore();
+  const inviteRef = db.collection("Invites").doc(token);
+  const inviteSnap = await inviteRef.get();
+
+  if (!inviteSnap.exists) {
+    return res.status(404).json({ error: "Invite not found" });
+  }
+
+  const invite = inviteSnap.data();
+
+  if (invite.usedAt) {
+    return res.status(410).json({ error: "This invite has already been used" });
+  }
+  if (invite.expiresAt.toMillis() < Date.now()) {
+    return res.status(410).json({ error: "This invite has expired" });
+  }
+  if (!decoded.email || decoded.email.toLowerCase() !== invite.email) {
+    return res
+      .status(403)
+      .json({ error: "This invite was issued to a different email address" });
+  }
+
+  await firebaseAdmin
+    .auth()
+    .setCustomUserClaims(decoded.uid, { role: invite.role, authorized: true });
+  await inviteRef.update({ usedAt: firebaseAdmin.firestore.Timestamp.now() });
+
+  // Keep it visible in User Manager alongside admin-granted roles.
+  const rosterCollection = invite.role === "lead" ? "Leads" : "Volunteers";
+  await db.collection(rosterCollection).add({
+    email: invite.email,
+    timestamp: firebaseAdmin.firestore.Timestamp.now(),
+  });
+
+  return res.status(200).json({ role: invite.role });
+}

--- a/pages/invite/[token].tsx
+++ b/pages/invite/[token].tsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useState } from "react";
+import { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  onAuthStateChanged,
+  updateProfile,
+  User,
+} from "firebase/auth";
+import { auth } from "firebaseClient";
+import { firebaseAdmin } from "firebaseAdmin";
+import { Typography, TextField, Button, CircularProgress } from "@mui/material";
+import { useSnackbar } from "notistack";
+import { FirebaseError } from "firebase/app";
+
+type InviteProps = {
+  valid: boolean;
+  error?: string;
+  email?: string;
+  role?: string;
+};
+
+export const getServerSideProps: GetServerSideProps<InviteProps> = async (
+  context,
+) => {
+  const { token } = context.params as { token: string };
+
+  try {
+    const snap = await firebaseAdmin
+      .firestore()
+      .collection("Invites")
+      .doc(token)
+      .get();
+
+    if (!snap.exists) {
+      return { props: { valid: false, error: "This invite link isn't valid." } };
+    }
+    const invite = snap.data();
+    if (invite.usedAt) {
+      return {
+        props: { valid: false, error: "This invite has already been used." },
+      };
+    }
+    if (invite.expiresAt.toMillis() < Date.now()) {
+      return {
+        props: {
+          valid: false,
+          error: "This invite has expired. Ask whoever sent it for a new one.",
+        },
+      };
+    }
+    return { props: { valid: true, email: invite.email, role: invite.role } };
+  } catch (error) {
+    return {
+      props: { valid: false, error: "Something went wrong loading this invite." },
+    };
+  }
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  lead: "project lead",
+  volunteer: "non-UW preceptor",
+};
+
+export default function InvitePage({ valid, error, email, role }: InviteProps) {
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const [user, setUser] = useState<User | null>(null);
+  const [checkingAuth, setCheckingAuth] = useState(true);
+  const [redeeming, setRedeeming] = useState(false);
+  const [mode, setMode] = useState<"signup" | "login">("signup");
+  const [formState, setFormState] = useState({ fullName: "", password: "" });
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setCheckingAuth(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  const redeem = async (firebaseUser: User) => {
+    setRedeeming(true);
+    try {
+      const idToken = await firebaseUser.getIdToken();
+      const res = await fetch("/api/redeem-invite", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify({ token: router.query.token }),
+      });
+      if (!res.ok) {
+        const { error: redeemError } = await res.json();
+        enqueueSnackbar(redeemError || "Couldn't redeem this invite", {
+          variant: "error",
+        });
+        setRedeeming(false);
+        return;
+      }
+      await firebaseUser.getIdTokenResult(true);
+      enqueueSnackbar(
+        `Welcome! You're all set up as a ${ROLE_LABEL[role || ""] || "team member"}.`,
+        { variant: "success", autoHideDuration: 5000 },
+      );
+      router.push("/");
+    } catch (err) {
+      enqueueSnackbar("Something went wrong redeeming this invite", {
+        variant: "error",
+      });
+      setRedeeming(false);
+    }
+  };
+
+  useEffect(() => {
+    if (
+      !checkingAuth &&
+      user &&
+      valid &&
+      user.email?.toLowerCase() === email?.toLowerCase()
+    ) {
+      redeem(user);
+    }
+    // Only re-run when auth state settles, not on every redeem() identity change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkingAuth, user, valid]);
+
+  if (!valid) {
+    return (
+      <div style={{ maxWidth: 420, margin: "4rem auto", textAlign: "center", padding: "0 1rem" }}>
+        <Typography variant="h5" gutterBottom>
+          Invite not available
+        </Typography>
+        <Typography color="text.secondary">{error}</Typography>
+      </div>
+    );
+  }
+
+  if (checkingAuth || redeeming) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", marginTop: "4rem" }}>
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (user && user.email?.toLowerCase() !== email?.toLowerCase()) {
+    return (
+      <div style={{ maxWidth: 420, margin: "4rem auto", textAlign: "center", padding: "0 1rem" }}>
+        <Typography variant="h5" gutterBottom>
+          Wrong account
+        </Typography>
+        <Typography color="text.secondary">
+          This invite is for <b>{email}</b>, but you&apos;re signed in as {user.email}.
+          Sign out and reopen this link to accept it.
+        </Typography>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    try {
+      const credential =
+        mode === "signup"
+          ? await createUserWithEmailAndPassword(
+              auth,
+              email as string,
+              formState.password,
+            )
+          : await signInWithEmailAndPassword(
+              auth,
+              email as string,
+              formState.password,
+            );
+
+      if (mode === "signup" && formState.fullName) {
+        await updateProfile(credential.user, { displayName: formState.fullName });
+      }
+      await redeem(credential.user);
+    } catch (err) {
+      if (err instanceof FirebaseError) {
+        if (err.code === "auth/email-already-in-use") {
+          setFormError("An account already exists for this email — switch to sign in below.");
+          setMode("login");
+        } else if (err.code === "auth/weak-password") {
+          setFormError("Password should be at least six characters.");
+        } else if (
+          err.code === "auth/invalid-credential" ||
+          err.code === "auth/wrong-password"
+        ) {
+          setFormError("Incorrect password.");
+        } else {
+          setFormError("Something went wrong, try again.");
+        }
+      }
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 420, margin: "4rem auto", padding: "0 1rem" }}>
+      <Typography variant="h5" gutterBottom>
+        You&apos;ve been invited as a {ROLE_LABEL[role || ""] || "team member"}
+      </Typography>
+      <Typography color="text.secondary" gutterBottom>
+        {mode === "signup"
+          ? "Create a password to finish setting up your account."
+          : "Sign in to accept this invite."}
+      </Typography>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "1.5rem" }}
+      >
+        <TextField label="Email" value={email} disabled fullWidth />
+        {mode === "signup" && (
+          <TextField
+            label="Full name"
+            value={formState.fullName}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, fullName: e.target.value }))
+            }
+            fullWidth
+          />
+        )}
+        <TextField
+          label="Password"
+          type="password"
+          required
+          value={formState.password}
+          onChange={(e) =>
+            setFormState((prev) => ({ ...prev, password: e.target.value }))
+          }
+          fullWidth
+        />
+        {formError && <Typography color="error">{formError}</Typography>}
+        <Button type="submit" variant="contained">
+          {mode === "signup" ? "Create account" : "Sign in"}
+        </Button>
+        <Button
+          type="button"
+          variant="text"
+          onClick={() => setMode(mode === "signup" ? "login" : "signup")}
+        >
+          {mode === "signup"
+            ? "Already have an account? Sign in"
+            : "Need to create an account instead?"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/pages/invitePreceptor.tsx
+++ b/pages/invitePreceptor.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from "react";
+import { useAuth } from "auth";
+import { auth } from "firebaseClient";
+import {
+  Typography,
+  TextField,
+  Button,
+  MenuItem,
+  Select,
+  InputLabel,
+  FormControl,
+  SelectChangeEvent,
+} from "@mui/material";
+import AuthorizationMessage from "./AuthorizationMessage";
+import { useSnackbar } from "notistack";
+
+export default function InvitePreceptorPage() {
+  const { user, isAdmin, isLead, isLoading } = useAuth();
+  const { enqueueSnackbar } = useSnackbar();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("volunteer");
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (isLoading) {
+    return null;
+  }
+  if (!user || (!isAdmin && !isLead)) {
+    return <AuthorizationMessage user={user} />;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setInviteLink(null);
+    setSubmitting(true);
+    try {
+      const token = await auth.currentUser?.getIdToken();
+      const res = await fetch("/api/create-invite", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          email: email.toLowerCase().trim(),
+          role: isAdmin ? role : "volunteer",
+        }),
+      });
+      if (!res.ok) {
+        const { error } = await res.json();
+        enqueueSnackbar(error || "Couldn't create invite", { variant: "error" });
+        return;
+      }
+      const { token: inviteToken } = await res.json();
+      setInviteLink(`${window.location.origin}/invite/${inviteToken}`);
+      setEmail("");
+    } catch (error) {
+      enqueueSnackbar("Couldn't create invite", { variant: "error" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!inviteLink) return;
+    await navigator.clipboard.writeText(inviteLink);
+    enqueueSnackbar("Link copied", { variant: "success", autoHideDuration: 2000 });
+  };
+
+  return (
+    <div style={{ maxWidth: 480, margin: "3rem auto", padding: "0 1rem" }}>
+      <Typography variant="h4" gutterBottom>
+        Invite a preceptor
+      </Typography>
+      <Typography color="text.secondary" gutterBottom>
+        Generate a link for someone to set up their account with access already
+        granted — no waiting on User Manager.
+      </Typography>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "1.5rem" }}
+      >
+        <TextField
+          label="Their email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        {isAdmin && (
+          <FormControl>
+            <InputLabel id="invite-role-label">Role</InputLabel>
+            <Select
+              labelId="invite-role-label"
+              label="Role"
+              value={role}
+              onChange={(e: SelectChangeEvent) => setRole(e.target.value)}
+            >
+              <MenuItem value="volunteer">Non-UW preceptor</MenuItem>
+              <MenuItem value="lead">Project lead</MenuItem>
+            </Select>
+          </FormControl>
+        )}
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={submitting}
+          style={{ backgroundColor: "#4b2e83" }}
+        >
+          Generate invite link
+        </Button>
+      </form>
+      {inviteLink && (
+        <div style={{ marginTop: "1.5rem", padding: "1rem", background: "#f5f5f5", borderRadius: 8 }}>
+          <Typography variant="body2" gutterBottom>
+            Share this link — it works once:
+          </Typography>
+          <Typography style={{ wordBreak: "break-all", fontFamily: "monospace", fontSize: "0.85rem" }}>
+            {inviteLink}
+          </Typography>
+          <Button onClick={copyLink} size="small" style={{ marginTop: "0.5rem" }}>
+            Copy
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes part of #207. Non-UW preceptors/project leads sign up and silently land on `authorized: false` with no one aware there's anything to review. This implements two of the options scoped in that issue's planning doc:

- **Admin notification**: `reconcile-role` now fires a notification (via the Firebase Trigger Email extension, writing to a `mail` Firestore collection) the moment a non-UW email has no matching role, instead of the request going unnoticed.
- **Invite links**: admins and leads can generate a single-use, 14-day-expiring invite link that pre-authorizes a specific email before they ever sign up. Leads are scoped to only invite the `volunteer` (non-UW preceptor) role — never `lead` or `admin` — so this doesn't widen who can edit existing accounts' roles.

## What changed

- `helpers/notifyAdmins.ts` — sends the pending-authorization notification
- `pages/api/reconcile-role.ts` — hooks the notification into the existing unauthorized-signup path, simplified the duplicate `setCustomUserClaims` calls
- `helpers/invites.ts` — token generation + per-role invite permission rules
- `pages/api/create-invite.ts` / `pages/api/redeem-invite.ts` — generate and redeem invites, backed by a new `Invites` Firestore collection
- `pages/invite/[token].tsx` — the page an invited preceptor lands on: validates the link server-side, walks them through signup/sign-in locked to the invited email, redeems automatically
- `pages/invitePreceptor.tsx` — where a lead or admin generates the link
- `components/footer.tsx` — added an "Invite a Preceptor" link, visible to admins and leads
- `.env.example` — documents the two new env vars this needs

## Before merging / deploying

- Enable the Firebase **Trigger Email** extension on the project and configure SMTP, watching the `mail` collection
- Set `ADMIN_NOTIFICATION_EMAILS` (comma-separated) — the team was still deciding who should be on this list as of this PR
- Set `NEXT_PUBLIC_SITE_URL` so notification emails link correctly

## Test plan

- [ ] `yarn build` / `next lint` pass (confirmed locally)
- [ ] Full `tsc` typecheck currently fails on `main` too (pre-existing `@types/node` version mismatch with `typescript@4.9.5`, unrelated to this change) — worth its own fix
- [ ] Sign up with a non-UW email against a real Firebase project and confirm the admin notification email is sent
- [ ] As an admin, generate an invite for a `lead` and a `volunteer`; as a lead, confirm the role selector is hidden and only `volunteer` invites can be created
- [ ] Redeem an invite as a brand-new email (signup flow) and as an existing account (sign-in flow); confirm a mismatched-email redemption is rejected
- [ ] Confirm an invite can't be redeemed twice and expired invites are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)